### PR TITLE
fix RemovedInDjango18Warning

### DIFF
--- a/djqmethod.py
+++ b/djqmethod.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 from functools import partial
 
@@ -42,12 +42,8 @@ class QMethodQuerySet(models.query.QuerySet, QMethodLookupMixin):
 
 
 class Manager(models.Manager, QMethodLookupMixin):
+    _queryset_class = QMethodQuerySet
 
     # If this is the default manager for a model, use this manager class for
     # relations (i.e. `group.people`, see README for details).
     use_for_related_fields = True
-
-    def get_queryset(self, *args, **kwargs):
-        return QMethodQuerySet(model=self.model, using=self._db)
-
-    get_query_set = get_queryset

--- a/djqmethod.py
+++ b/djqmethod.py
@@ -47,5 +47,7 @@ class Manager(models.Manager, QMethodLookupMixin):
     # relations (i.e. `group.people`, see README for details).
     use_for_related_fields = True
 
-    def get_query_set(self, *args, **kwargs):
+    def get_queryset(self, *args, **kwargs):
         return QMethodQuerySet(model=self.model, using=self._db)
+
+    get_query_set = get_queryset

--- a/djqmethod.py
+++ b/djqmethod.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 from functools import partial
 


### PR DESCRIPTION
fix warning with Django 1.7:

```
RemovedInDjango18Warning: `Manager.get_query_set` method should be renamed `get_queryset`.
```
